### PR TITLE
Add `watch` and `pretest` back to scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,8 +59,10 @@
 	"scripts": {
 		"vscode:prepublish": "npm run check && npm run compile",
 		"compile": "tsc -p ./",
+		"watch": "tsc -watch -p ./",
 		"check": "prettier --check src/ && eslint src --ext ts",
-		"fix": "prettier --write src/ && eslint src --ext ts --fix"
+		"fix": "prettier --write src/ && eslint src --ext ts --fix",
+		"pretest": "npm run compile && npm run check"
 	},
 	"devDependencies": {
 		"@types/glob": "^7.1.3",


### PR DESCRIPTION
I deleted the `watch` and `pretest` npm run scripts thinking that they
are unnecessary. However, VS Code runs them and expects them to be there
by convention.