### PR TITLE
Deprecate `mristin` as the publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # crosshair-vscode
 
+> ❗ **IMPORTANT** ❗ \
+> **This extension was migrated from the publisher `mristin` to a new publisher, `crosshair`. Please uninstall this extension and install [the new extension] instead.**
+
+[the new extension]: https://marketplace.visualstudio.com/items?itemName=CrossHair.crosshair
+
 Crosshair-vscode is an extension for [Visual Studio Code (VS Code)][vscode] that
 allows you to statically test your Python code using [CrossHair][crosshair-tool].
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "crosshair",
-	"displayName": "crosshair-vscode",
+	"displayName": "[MIGRATED TO A NEW PUBLISHER] crosshair-vscode",
 	"description": "Use crosshair to statically analyze Python code from within VS Code.",
 	"version": "0.0.2",
 	"license": "MIT",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -578,6 +578,28 @@ export async function activate(context: vscode.ExtensionContext) {
     )
   )
 
+  const updateNowItem = { title: 'Upgrade now' }
+  vscode.window
+    .showWarningMessage(
+      'The extension was migrated from the publisher mristin ' +
+      'to a new publisher, crosshair. Please upgrade now.',
+      updateNowItem
+    )
+    .then(async (value) => {
+      if (value === updateNowItem) {
+        await vscode.commands.executeCommand(
+          'workbench.extensions.uninstallExtension',
+          'mristin.crosshair-vscode'
+        )
+        await vscode.commands.executeCommand(
+          'workbench.extensions.installExtension',
+          'crosshair.crosshair',
+          { installPreReleaseVersion: true }
+        )
+        await vscode.commands.executeCommand('workbench.action.reloadWindow')
+      }
+    })
+
   return initializePython(context.subscriptions).then(() => {
     if (localState?.wantsToRun) {
       return restartServer()


### PR DESCRIPTION
We migrate the extension to a project publisher, `crosshair`, instead of the individual contributor, `mristin`.